### PR TITLE
build: use meson's unstable-wayland module.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
 	'c',
 	version: '1.7.0',
 	license: 'MIT',
-	meson_version: '>=0.59.0',
+	meson_version: '>=0.62.0',
 	default_options: [
 		'c_std=c11',
 		'warning_level=3',

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -1,27 +1,14 @@
-wayland_scanner = find_program('wayland-scanner')
+wl_mod = import('unstable-wayland')
 
-wayland_scanner = dependency('wayland-scanner', version: '>=1.14.91', native: true)
-wayland_scanner_path = wayland_scanner.get_variable(pkgconfig: 'wayland_scanner')
-wayland_scanner_prog = find_program(wayland_scanner_path, native: true)
-
-wayland_scanner_code = generator(
-	wayland_scanner_prog,
-	output: '@BASENAME@-protocol.c',
-	arguments: ['private-code', '@INPUT@', '@OUTPUT@'],
+wlr_output_management = wl_mod.find_protocol(
+  'wlr-output-management',
+  state: 'unstable',
+  version: 1,
+  vendored: true,
 )
 
-wayland_scanner_client = generator(
-	wayland_scanner_prog,
-	output: '@BASENAME@-client-protocol.h',
-	arguments: ['client-header', '@INPUT@', '@OUTPUT@'],
+protocols_src = wl_mod.scan_xml(
+  wlr_output_management,
+  client: true,
+  server: false,
 )
-
-protocols = [
-	'wlr-output-management-unstable-v1.xml',
-]
-
-protocols_src = []
-foreach xml : protocols
-	protocols_src += wayland_scanner_code.process(xml)
-	protocols_src += wayland_scanner_client.process(xml)
-endforeach


### PR DESCRIPTION
This simplifies usage of wayland-scanner.